### PR TITLE
Switch power network graph to MultiGraph

### DIFF
--- a/Code/plot_utils.py
+++ b/Code/plot_utils.py
@@ -30,22 +30,22 @@ def plot_power_flow(m, G, i, j):
     edge_colors = []
     edge_labels = {}
 
-    for u, v in G.edges():
+    for u, v, k in G.edges(keys=True):
         try:
             # Correct the sign of the flow value for plotting
-            flow_value = m.F[u, v, i, j].value
+            flow_value = m.F[u, v, k, i, j].value
             if flow_value is not None:
-                edge_labels[(u, v)] = f"{round(flow_value, 4)}"
+                edge_labels[(u, v, k)] = f"{round(flow_value, 4)}"
                 if flow_value > 0:
-                    edge_colors.append('blue')  # Positive flow (now correctly represents flow from u to v)
+                    edge_colors.append('blue')  # Positive flow
                 elif flow_value < 0:
-                    edge_colors.append('red')  # Negative (reverse) flow (now correctly represents flow from v to u)
+                    edge_colors.append('red')  # Negative flow
                 else:
-                    edge_colors.append('gray') # No flow
+                    edge_colors.append('gray')  # No flow
             else:
-                edge_colors.append('gray') # No flow value
-        except:
-            edge_colors.append('gray') # Handle cases where edge might not be in m.F
+                edge_colors.append('gray')  # No flow value
+        except Exception:
+            edge_colors.append('gray')  # Handle cases where edge might not be in m.F
 
     # Draw the network
     nx.draw(

--- a/Code/pyo_environment.py
+++ b/Code/pyo_environment.py
@@ -20,13 +20,13 @@ def create_pyo_env(graph,
         operational_nodes = list(G_full.nodes)
 
     # --- Définition du graphe opérationnel ---
-    G = G_full.subgraph(operational_nodes)
+    G = G_full.subgraph(operational_nodes).copy()
 
     # Création du modèle
     m = pyo.ConcreteModel()
 
     m.Nodes = pyo.Set(initialize=[b for b in G.nodes])
-    m.Lines = pyo.Set(initialize=[l for l in G.edges])
+    m.Lines = pyo.Set(initialize=[(u, v, k) for u, v, k in G.edges(keys=True)])
     m.i = pyo.Set(initialize=[0, 1])  # Initialize m.i with two generic elements
     m.j = pyo.Set(initialize=[0, 1])
 
@@ -75,24 +75,24 @@ def create_pyo_env(graph,
     m.I_min = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): calculate_current_bounds(
+            (u, v, k): calculate_current_bounds(
                 G,
-                G[u][v].get("max_i_ka"),
+                G[u][v][k].get("max_i_ka"),
                 G.nodes[u]["vn_kv"],
             )[0]
-            for (u, v) in m.Lines
+            for (u, v, k) in m.Lines
         },
         domain=pyo.Reals,
     )
     m.I_max = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): calculate_current_bounds(
+            (u, v, k): calculate_current_bounds(
                 G,
-                G[u][v].get("max_i_ka"),
+                G[u][v][k].get("max_i_ka"),
                 G.nodes[u]["vn_kv"],
             )[1]
-            for (u, v) in m.Lines
+            for (u, v, k) in m.Lines
         },
         domain=pyo.Reals,
     )


### PR DESCRIPTION
## Summary
- Replace simple graphs with `nx.MultiGraph` to support parallel circuits and preserve edge keys and attributes
- Adjust graph utilities, Pyomo environment, and optimization routines to handle multi-edge structures
- Update plotting helper to display flows for keyed edges

## Testing
- `python -m py_compile Code/graph.py Code/pyo_environment.py Code/optimization.py Code/plot_utils.py`
- `pytest -q`
- `python - <<'PY'
import sys; sys.path.append('Code'); import graph, pyo_environment; import pandapower.networks as pn
net = pn.example_multivoltage(); G = graph.create_graph(net)
PY` *(fails: ImportError: igraph not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e57f76483238acdac13822d69c9