### PR TITLE
Apply consumption/production sign convention and add alpha plot

### DIFF
--- a/Code/graph.py
+++ b/Code/graph.py
@@ -97,9 +97,9 @@ def create_graph(net: Any) -> nx.Graph:
     for _, row in net.ext_grid.iterrows():
         G.nodes[row["bus"]]["P_gen"] += 70.0 / s_base
 
-    # Calcul de P
+    # Calcul de P (convention : P<0 production, P>0 consommation)
     for n in G.nodes:
-        G.nodes[n]["P"] = G.nodes[n]["P_gen"] - G.nodes[n]["P_load"]
+        G.nodes[n]["P"] = G.nodes[n]["P_load"] - G.nodes[n]["P_gen"]
 
     # -------------------------
     # Donner accès à G
@@ -147,9 +147,9 @@ def plot_network(G, labels=None, node_colors=None):
     # -------------------------
     node_colors = []
     for n, data in G.nodes(data=True):
-        if data["P"] > 0:
+        if data["P"] < 0:
             node_colors.append("green")  # producteur
-        elif data["P"] < 0:
+        elif data["P"] > 0:
             node_colors.append("red")  # consommateur
         else:
             node_colors.append("gray")  # neutre

--- a/Code/plot_utils.py
+++ b/Code/plot_utils.py
@@ -105,3 +105,53 @@ def plot_DOE(m, filename="child_nodes_envelopes.pdf"):
     plt.grid(True)
     plt.savefig(filename)
     plt.show()
+
+
+def plot_alloc_alpha(A, enveloppe_taille, curtail, close, somme_contributions,
+                     beta=None, filename="DOE_alloc_alpha.pdf"):
+    """Plot envelope volume, curtailment and DSO deviation versus alpha.
+
+    Parameters
+    ----------
+    A : Sequence[float]
+        Values of the parameter alpha.
+    enveloppe_taille, curtail, close, somme_contributions : Sequence[float]
+        Metrics to plot as a function of alpha. ``close`` represents the
+        deviation of the center of the envelope from the DSO estimation and
+        ``somme_contributions`` is the sum of this deviation and the envelope
+        volume.
+    beta : float, optional
+        If provided, displayed in the plot title.
+    filename : str, optional
+        PDF file name for saving the plot.
+    """
+
+    alpha_values = np.array(A)
+
+    enveloppe_taille_np = np.array(enveloppe_taille, dtype=float)
+    curtail_np = np.array(curtail, dtype=float)
+    close_np = np.array(close, dtype=float)
+    somme_contributions_np = np.array(somme_contributions, dtype=float)
+
+    plt.figure(figsize=(10, 6))
+
+    plt.plot(alpha_values, enveloppe_taille_np, marker='o', linestyle='-',
+             label='Envelope Volume')
+    plt.plot(alpha_values, curtail_np, marker='x', linestyle='--',
+             label='Curtailment')
+    plt.plot(alpha_values, close_np, marker='s', linestyle='--', color='blue',
+             label='Deviation of the center of the envelope from DSO estimation')
+    plt.plot(alpha_values, somme_contributions_np, marker='^', linestyle=':',
+             color='red',
+             label='Deviation of the center of the envelope from DSO estimation + Envelope Volume')
+
+    plt.xlabel('$\\alpha$')
+    plt.ylabel('Power (per-unit)')
+    if beta is not None:
+        plt.title('Evolution of the volume of the envelope, curtailment and '
+                  'closeness to DSO estimation as a function of parameter '
+                  f'Alpha (beta={beta})')
+    plt.legend()
+    plt.grid(True)
+    plt.savefig(filename)
+    plt.show()

--- a/Code/pyo_environment.py
+++ b/Code/pyo_environment.py
@@ -54,9 +54,13 @@ def create_pyo_env(
     m.i = pyo.Set(initialize=[0, 1])  # Initialize m.i with two generic elements
     m.j = pyo.Set(initialize=[0, 1])
 
-    m.P = pyo.Param(m.Nodes,
-                    initialize={n: - G.nodes[n].get('P') for n in G.nodes},
-                    domain=pyo.Reals, mutable=True)
+    # Convention de signe : P < 0 production, P > 0 consommation
+    m.P = pyo.Param(
+        m.Nodes,
+        initialize={n: G.nodes[n].get('P') for n in G.nodes},
+        domain=pyo.Reals,
+        mutable=True,
+    )
 
     # --- Définir parents/enfants dynamiquement ---
     if parent_nodes is None:


### PR DESCRIPTION
## Summary
- enforce power sign convention globally (P<0 for production, P>0 for consumption)
- adjust network visualization to reflect new convention
- add plot function to visualize envelope volume, curtailment, and DSO deviation vs alpha

## Testing
- `python -m py_compile Code/graph.py Code/pyo_environment.py Code/plot_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad74fc7f148323a827c80bd10b1996