### PR TITLE
feat: add alpha sweep plotting

### DIFF
--- a/Code/init.py
+++ b/Code/init.py
@@ -10,7 +10,7 @@ puis de lancer :  init.py
 """
 from check_requirements import install_missing_packages
 from optimization import optim_problem
-from plot_utils import plot_power_flow
+from plot_utils import plot_power_flow, plot_alloc_alpha
 import pandapower.networks as pn
 
 # ---- Paramétrage utilisateur ----
@@ -21,9 +21,31 @@ CHILDREN_NODES    = [1, 2, 3, 4, 5]
 # Parameters of the objective function
 ALPHA = 1
 BETA = 1
+
+# Optional sweep of alpha to visualise its impact on the optimisation.
+# Set ``PLOT_ALPHA`` to ``True`` to launch :func:`plot_alloc_alpha` with the
+# following bounds and step.
+PLOT_ALPHA = False
+ALPHA_MIN = 0.0
+ALPHA_MAX = 1.0
+ALPHA_STEP = 0.1
 # ---------------------------------
 
 install_missing_packages()
+
+# Optionally scan multiple ``alpha`` values and display the resulting metrics
+# before running the main optimisation.
+if PLOT_ALPHA:
+    plot_alloc_alpha(
+        test_case=TEST_CASE,
+        operational_nodes=OPERATIONAL_NODES,
+        parent_nodes=PARENT_NODES,
+        children_nodes=CHILDREN_NODES,
+        beta=BETA,
+        alpha_min=ALPHA_MIN,
+        alpha_max=ALPHA_MAX,
+        alpha_step=ALPHA_STEP,
+    )
 
 res = optim_problem(
     test_case=TEST_CASE,

--- a/Code/init.py
+++ b/Code/init.py
@@ -25,7 +25,7 @@ BETA = 1
 # Optional sweep of alpha to visualise its impact on the optimisation.
 # Set ``PLOT_ALPHA`` to ``True`` to launch :func:`plot_alloc_alpha` with the
 # following bounds and step.
-PLOT_ALPHA = False
+PLOT_ALPHA = True
 ALPHA_MIN = 0.0
 ALPHA_MAX = 1.0
 ALPHA_STEP = 0.1

--- a/Code/optimization.py
+++ b/Code/optimization.py
@@ -31,6 +31,7 @@ def optim_problem(
     children_nodes=None,
     alpha: float = 1.0,
     beta: float = 1.0,
+    plot_doe: bool = True,
 ):
     """Run either an OPF or DOE optimisation on the given network.
 
@@ -42,6 +43,10 @@ def optim_problem(
         Definition of the operational perimeter and boundary nodes.
     alpha, beta: float
         Weights used in the objective function of the DOE optimisation.
+    plot_doe: bool
+        If ``True`` the DOE result for each run is plotted.  This is mainly
+        useful for interactive debugging; when scanning many ``alpha`` values
+        the plots can be disabled to avoid cluttering the output.
     """
 
     # 1) Charger le réseau et créer le graphe complet
@@ -90,5 +95,6 @@ def optim_problem(
     m, G = env_op
     constraints.constraints(m, G)  # crée m.objective_doe
     result = _solve_and_pack(m, G, "objective_doe")
-    plot_DOE(m)
+    if plot_doe:
+        plot_DOE(m)
     return {"operational": result}

--- a/Code/plot_utils.py
+++ b/Code/plot_utils.py
@@ -81,7 +81,7 @@ def plot_power_flow(m, G, i, j):
     plt.show()
 
 
-def plot_DOE(m, filename="child_nodes_envelopes.pdf"):
+def plot_DOE(m, filename="Figures/Child_nodes_envelopes.pdf"):
     """Plot power envelope and DSO estimation for child nodes."""
     children = list(m.children)
     p0 = [getattr(m.P_C_set[n, 0], "value", m.P_C_set[n, 0]) for n in children]
@@ -117,7 +117,7 @@ def plot_alloc_alpha(
     alpha_max: float = 1.0,
     alpha_step: float = 0.1,
     show: bool = True,
-    filename: str = "DOE_alloc_alpha.pdf",
+    filename: str = "Figures/DOE_alloc_alpha.pdf",
 ):
     """Run the optimisation for several ``alpha`` values and optionally plot the
     evolution of key metrics.


### PR DESCRIPTION
## Summary
- allow `optim_problem` to skip DOE plotting
- sweep alpha values and optionally plot metrics with new `plot_alloc_alpha`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad78ca707883239defb07139210b30