### PR TITLE
Compute per-unit line current limits during graph construction

### DIFF
--- a/core/constraints_common.py
+++ b/core/constraints_common.py
@@ -96,6 +96,7 @@ def add_power_balance(m):
     m.power_balance = pyo.Constraint(m.Nodes, m.VertP, m.VertV, rule=power_balance_rule)
 
 
+
 def add_phase_bounds(m):
     """Bound voltage angle variables between ``theta_min`` and ``theta_max``."""
 

--- a/core/constraints_doe.py
+++ b/core/constraints_doe.py
@@ -33,10 +33,10 @@ def apply(m, G):
 
     m.worst_case = pyo.Constraint(m.children, m.VertP, m.VertV, rule=worst_case_children)
 
-    # def logical_constraint_rule(m, u):
-    #     return m.P_C_set[u, 0] >= m.P_C_set[u, 1]
-    #
-    # m.logical_constraint = pyo.Constraint(m.children, rule=logical_constraint_rule)
+    def logical_constraint_rule(m, u):
+        return m.P_C_set[u, 0] >= m.P_C_set[u, 1]
+
+    m.logical_constraint = pyo.Constraint(m.children, rule=logical_constraint_rule)
 
     def children_voltage_rule(m, children, vp, vv):
         return pyo.inequality(m.V_min, m.V[children, vp, vv], m.V_max)

--- a/core/constraints_doe.py
+++ b/core/constraints_doe.py
@@ -17,12 +17,6 @@ from .constraints_common import (
 def apply(m, G):
     """Apply DOE constraints and objective to model `m`."""
 
-    # Children nodes consumption envelope
-    def worst_case_children(m, u, vp, vv):
-        return m.P_C_set[u, vp] == m.P_minus[u, vp, vv]
-
-    m.worst_case = pyo.Constraint(m.children, m.VertP, m.VertV, rule=worst_case_children)
-
     # Common constraints
     add_curtailment_abs(m)
     add_current_bounds(m, G)
@@ -32,6 +26,17 @@ def apply(m, G):
     add_power_balance(m, G)
     add_parent_power_bounds(m)
     add_voltage_vertices(m)
+
+    # Children nodes consumption envelope
+    def worst_case_children(m, u, vp, vv):
+        return m.P_C_set[u, vp] == m.P_minus[u, vp, vv]
+
+    m.worst_case = pyo.Constraint(m.children, m.VertP, m.VertV, rule=worst_case_children)
+
+    def logical_constraint_rule(m, n):
+        return m.P_C_set[n, 0] >= m.P_C_set[n, 1]
+
+    m.logical_constraint = pyo.Constraint(m.children, rule=logical_constraint_rule)
 
     # Envelope volume and DSO gap
     def aux_constraint_rule(m, u):

--- a/core/constraints_doe.py
+++ b/core/constraints_doe.py
@@ -19,11 +19,11 @@ def apply(m, G):
 
     # Common constraints
     add_curtailment_abs(m)
-    add_current_bounds(m, G)
+    add_current_bounds(m)
     add_dc_flow_constraints(m, G)
     add_current_definition(m)
     add_phase_bounds(m)
-    add_power_balance(m, G)
+    add_power_balance(m)
     add_parent_power_bounds(m)
     add_voltage_vertices(m)
 
@@ -33,10 +33,15 @@ def apply(m, G):
 
     m.worst_case = pyo.Constraint(m.children, m.VertP, m.VertV, rule=worst_case_children)
 
-    def logical_constraint_rule(m, n):
-        return m.P_C_set[n, 0] >= m.P_C_set[n, 1]
+    # def logical_constraint_rule(m, u):
+    #     return m.P_C_set[u, 0] >= m.P_C_set[u, 1]
+    #
+    # m.logical_constraint = pyo.Constraint(m.children, rule=logical_constraint_rule)
 
-    m.logical_constraint = pyo.Constraint(m.children, rule=logical_constraint_rule)
+    def children_voltage_rule(m, children, vp, vv):
+        return pyo.inequality(m.V_min, m.V[children, vp, vv], m.V_max)
+
+    m.children_voltage = pyo.Constraint(m.children, m.VertP, m.VertV, rule=children_voltage_rule)
 
     # Envelope volume and DSO gap
     def aux_constraint_rule(m, u):
@@ -51,14 +56,14 @@ def apply(m, G):
 
     def diff_dso_rule(m, u):
         return -m.diff_DSO[u] <= (
-            (m.P_C_set[u, 0] + m.P_C_set[u, 1]) / 2 - m.info_DSO_param[u]
+                ((m.P_C_set[u, 0] + m.P_C_set[u, 1]) / 2) - m.info_DSO_param[u]
         )
 
     m.diff_DSO_constraint = pyo.Constraint(m.children, rule=diff_dso_rule)
 
     def diff_bis_dso_rule(m, u):
         return (
-            (m.P_C_set[u, 0] + m.P_C_set[u, 1]) / 2 - m.info_DSO_param[u]
+                ((m.P_C_set[u, 0] + m.P_C_set[u, 1]) / 2) - m.info_DSO_param[u]
             <= m.diff_DSO[u]
         )
 
@@ -111,9 +116,7 @@ def apply(m, G):
     # Objective
     def objective_rule_doe(m):
         return (
-            m.envelope_volume
-            - m.alpha * m.curtailment_budget
-            - m.beta * m.envelope_center_gap
+            m.envelope_volume -(m.alpha * m.curtailment_budget) -(m.beta * m.envelope_center_gap)
         )
 
     m.objective_doe = pyo.Objective(rule=objective_rule_doe, sense=pyo.maximize)

--- a/core/constraints_opf.py
+++ b/core/constraints_opf.py
@@ -27,6 +27,6 @@ def apply(m, G):
     add_voltage_vertices(m)
 
     def objective_rule_opf(m):
-        return m.alpha * m.curtailment_budget
+        return -m.alpha * m.curtailment_budget
 
-    m.objective_opf = pyo.Objective(rule=objective_rule_opf, sense=pyo.minimize)
+    m.objective_opf = pyo.Objective(rule=objective_rule_opf, sense=pyo.maximize)

--- a/core/graph.py
+++ b/core/graph.py
@@ -38,7 +38,7 @@ def extract_network_data(net: Any) -> Dict[str, Any]:
     else:
         raise AttributeError("Bus positions not available in network.")
 
-    s_base = getattr(net, "sn_mva", 100.0)
+    s_base = 100.0 #MVA
 
     # Gather nodal powers
     P_load = {idx: 0.0 for idx in net.bus.index}
@@ -53,6 +53,9 @@ def extract_network_data(net: Any) -> Dict[str, Any]:
         P_gen[row["bus"]] += -float(row.get("p_mw", 0.0)) / s_base
     # Net nodal power: positive = consumption, negative = production
     P = {idx: P_load[idx] + P_gen[idx] for idx in net.bus.index}
+
+    print (s_base)
+    print(idx, P)
 
     return {
         "pos": pos,
@@ -75,7 +78,8 @@ def build_graph_from_data(data: Dict[str, Any]) -> nx.Graph:
     """
 
     G = nx.Graph()
-    G.graph["s_base"] = data["s_base"]
+
+    data["s_base"] = 100 #MVA
 
     # Nodes
     for idx, row in data["bus"].iterrows():
@@ -100,7 +104,7 @@ def build_graph_from_data(data: Dict[str, Any]) -> nx.Graph:
         if max_i_ka is not None and not math.isnan(max_i_ka):
             I_max_pu = max_i_ka / base_i_ka
         else:
-            I_max_pu = 1000
+            I_max_pu = 10
         I_min_pu = -I_max_pu
         G.add_edge(
             u,

--- a/core/graph.py
+++ b/core/graph.py
@@ -54,9 +54,6 @@ def extract_network_data(net: Any) -> Dict[str, Any]:
     # Net nodal power: positive = consumption, negative = production
     P = {idx: P_load[idx] + P_gen[idx] for idx in net.bus.index}
 
-    print (s_base)
-    print(idx, P)
-
     return {
         "pos": pos,
         "s_base": s_base,
@@ -79,7 +76,7 @@ def build_graph_from_data(data: Dict[str, Any]) -> nx.Graph:
 
     G = nx.Graph()
 
-    data["s_base"] = 100 #MVA
+    s_base = 100.0 #MVA
 
     # Nodes
     for idx, row in data["bus"].iterrows():
@@ -98,9 +95,9 @@ def build_graph_from_data(data: Dict[str, Any]) -> nx.Graph:
         u, v = row["from_bus"], row["to_bus"]
         x_ohm = row["x_ohm_per_km"] * row["length_km"]
         V_kv = data["bus"].at[u, "vn_kv"]
-        b_pu = V_kv**2 / (x_ohm * data["s_base"])
+        b_pu = V_kv**2 / (x_ohm * s_base)
         max_i_ka = row.get("max_i_ka")
-        base_i_ka = data["s_base"] / (math.sqrt(3) * V_kv)
+        base_i_ka = s_base / (math.sqrt(3) * V_kv)
         if max_i_ka is not None and not math.isnan(max_i_ka):
             I_max_pu = max_i_ka / base_i_ka
         else:

--- a/core/graph.py
+++ b/core/graph.py
@@ -50,8 +50,9 @@ def extract_network_data(net: Any) -> Dict[str, Any]:
     for _, row in net.sgen.iterrows():
         P_gen[row["bus"]] += -row["p_mw"] / s_base
     for _, row in net.ext_grid.iterrows():
-        P_gen[row["bus"]] += -70.0 / s_base
-    P = {idx: P_load[idx] - P_gen[idx] for idx in net.bus.index}
+        P_gen[row["bus"]] += -float(row.get("p_mw", 0.0)) / s_base
+    # Net nodal power: positive = consumption, negative = production
+    P = {idx: P_load[idx] + P_gen[idx] for idx in net.bus.index}
 
     return {
         "pos": pos,

--- a/core/optimization.py
+++ b/core/optimization.py
@@ -20,6 +20,16 @@ def _solve_and_pack(m, G, objective_name: str):
     results = solver.solve(m, tee=True)
     status = str(results.solver.status)
     obj = pyo.value(getattr(m, objective_name))
+    for u, v, vp, vv in m.F:
+        print(
+            f"Flow on line ({u}, {v}) for P vertex {vp} and V vertex {vv}: "
+            f"{pyo.value(m.F[u, v, vp, vv])}"
+        )
+    for u, v, vp, vv in m.I:
+        print(
+            f"Current flow on line ({u}, {v}) for P vertex {vp} and V vertex {vv}: "
+            f"I = {pyo.value(m.I[u, v, vp, vv])}"
+        )
     return {"status": status, "objective": obj, "model": m, "graph": G}
 
 

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -52,8 +52,8 @@ def build_params(m, G, info_DSO, alpha, beta):
     m.V_P = pyo.Param(m.VertV, initialize={0: 0.9, 1: 1.1}, domain=pyo.NonNegativeReals)
     m.P_min = pyo.Param(initialize=-0.0)
     m.P_max = pyo.Param(initialize=0.0)
-    m.theta_min = pyo.Param(initialize=-math.pi)
-    m.theta_max = pyo.Param(initialize=math.pi)
+    m.theta_min = pyo.Param(initialize=-1)
+    m.theta_max = pyo.Param(initialize=1)
     m.alpha = pyo.Param(initialize=alpha)
     m.beta = pyo.Param(initialize=beta)
     m.I_min = pyo.Param(

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -82,9 +82,9 @@ def build_variables(m, G):
     m.P_plus = pyo.Var(m.parents, m.VertP, m.VertV, domain=pyo.Reals)
     # Bound child injections to realistic per-unit range
     m.P_minus = pyo.Var(
-        m.children, m.VertP, m.VertV, domain=pyo.Reals, bounds=(-1, 1)
+        m.children, m.VertP, m.VertV, domain=pyo.Reals
     )
-    m.P_C_set = pyo.Var(m.children, m.VertP, domain=pyo.Reals, bounds=(-1, 1))
+    m.P_C_set = pyo.Var(m.children, m.VertP, domain=pyo.Reals)
     m.z = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.NonNegativeReals)
     m.curt = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.Reals)
     m.aux = pyo.Var(m.children, domain=pyo.Reals)

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -11,8 +11,6 @@ from typing import Dict, Optional
 
 import pyomo.environ as pyo
 
-from .graph import calculate_current_bounds
-
 
 def build_sets(m, G, parent_nodes, children_nodes):
     """Create model sets."""
@@ -53,20 +51,14 @@ def build_params(m, G, info_DSO, alpha, beta):
     m.I_min = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): calculate_current_bounds(
-                G, G[u][v].get("max_i_ka"), G.nodes[u]["vn_kv"]
-            )[0]
-            for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_min_pu", -1000) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )
     m.I_max = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): calculate_current_bounds(
-                G, G[u][v].get("max_i_ka"), G.nodes[u]["vn_kv"]
-            )[1]
-            for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_max_pu", 1000) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -59,14 +59,14 @@ def build_params(m, G, info_DSO, alpha, beta):
     m.I_min = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): G[u][v].get("I_min_pu", -1000) for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_min_pu", -10) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )
     m.I_max = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): G[u][v].get("I_max_pu", 1000) for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_max_pu", 10) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -50,8 +50,8 @@ def build_params(m, G, info_DSO, alpha, beta):
     m.V_min = pyo.Param(initialize=0.9)
     m.V_max = pyo.Param(initialize=1.1)
     m.V_P = pyo.Param(m.VertV, initialize={0: 0.9, 1: 1.1}, domain=pyo.NonNegativeReals)
-    m.P_min = pyo.Param(initialize=-0.3)
-    m.P_max = pyo.Param(initialize=0.3)
+    m.P_min = pyo.Param(initialize=-0.0)
+    m.P_max = pyo.Param(initialize=0.0)
     m.theta_min = pyo.Param(initialize=-math.pi)
     m.theta_max = pyo.Param(initialize=math.pi)
     m.alpha = pyo.Param(initialize=alpha)
@@ -59,14 +59,14 @@ def build_params(m, G, info_DSO, alpha, beta):
     m.I_min = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): G[u][v].get("I_min_pu", -10) for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_min_pu", -1) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )
     m.I_max = pyo.Param(
         m.Lines,
         initialize={
-            (u, v): G[u][v].get("I_max_pu", 10) for (u, v) in m.Lines
+            (u, v): G[u][v].get("I_max_pu", 1) for (u, v) in m.Lines
         },
         domain=pyo.Reals,
     )

--- a/core/pyo_environment.py
+++ b/core/pyo_environment.py
@@ -30,15 +30,23 @@ def build_params(m, G, info_DSO, alpha, beta):
         domain=pyo.Reals,
         mutable=True,
     )
-    m.PositiveNodes = pyo.Set(initialize=[n for n in m.Nodes if G.nodes[n].get("P", 0.0) >= 0])
-    m.NegativeNodes = pyo.Set(initialize=[n for n in m.Nodes if G.nodes[n].get("P", 0.0) <= 0])
+    m.PositiveNodes = pyo.Set(
+        initialize=[n for n in m.Nodes if G.nodes[n].get("P", 0.0) > 0]
+    )
+    m.NegativeNodes = pyo.Set(
+        initialize=[n for n in m.Nodes if G.nodes[n].get("P", 0.0) < 0]
+    )
     m.info_DSO_param = pyo.Param(
         m.children,
         initialize={n: float(info_DSO.get(n, 0.0)) for n in m.children},
         domain=pyo.Reals,
     )
-    m.positive_demand = pyo.Set(initialize=[n for n in m.children if pyo.value(m.info_DSO_param[n]) >= 0])
-    m.negative_demand = pyo.Set(initialize=[n for n in m.children if pyo.value(m.info_DSO_param[n]) <= 0])
+    m.positive_demand = pyo.Set(
+        initialize=[n for n in m.children if pyo.value(m.info_DSO_param[n]) > 0]
+    )
+    m.negative_demand = pyo.Set(
+        initialize=[n for n in m.children if pyo.value(m.info_DSO_param[n]) < 0]
+    )
     m.V_min = pyo.Param(initialize=0.9)
     m.V_max = pyo.Param(initialize=1.1)
     m.V_P = pyo.Param(m.VertV, initialize={0: 0.9, 1: 1.1}, domain=pyo.NonNegativeReals)
@@ -72,8 +80,11 @@ def build_variables(m, G):
     m.V = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.NonNegativeReals)
     m.E = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.Reals)
     m.P_plus = pyo.Var(m.parents, m.VertP, m.VertV, domain=pyo.Reals)
-    m.P_minus = pyo.Var(m.children, m.VertP, m.VertV, domain=pyo.Reals)
-    m.P_C_set = pyo.Var(m.children, m.VertP, domain=pyo.Reals)
+    # Bound child injections to realistic per-unit range
+    m.P_minus = pyo.Var(
+        m.children, m.VertP, m.VertV, domain=pyo.Reals, bounds=(-1, 1)
+    )
+    m.P_C_set = pyo.Var(m.children, m.VertP, domain=pyo.Reals, bounds=(-1, 1))
     m.z = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.NonNegativeReals)
     m.curt = pyo.Var(m.Nodes, m.VertP, m.VertV, domain=pyo.Reals)
     m.aux = pyo.Var(m.children, domain=pyo.Reals)

--- a/init.py
+++ b/init.py
@@ -90,3 +90,5 @@ if "full" in res:
     plot_power_flow(res["full"]["model"], res["full"]["graph"], 0, 0)
 if "operational" in res:
     plot_power_flow(res["operational"]["model"], res["operational"]["graph"], 0, 0)
+
+

--- a/init.py
+++ b/init.py
@@ -23,8 +23,8 @@ OPERATIONAL_NODES = [0, 1, 2, 3, 4, 5]  # [] => OPF ; sinon => DOE
 PARENT_NODES = [0]
 CHILDREN_NODES = [1, 2, 3, 4, 5]
 # Parameters of the objective function
-ALPHA = 3
-BETA = 3
+ALPHA = 2
+BETA = 1
 
 # Optional sweep of alpha to visualise its impact on the optimisation.
 # Set ``PLOT_ALPHA`` to ``True`` to launch :func:`plot_alloc_alpha` with the

--- a/init.py
+++ b/init.py
@@ -23,7 +23,7 @@ OPERATIONAL_NODES = [0, 1, 2, 3, 4, 5]  # [] => OPF ; sinon => DOE
 PARENT_NODES = [0]
 CHILDREN_NODES = [1, 2, 3, 4, 5]
 # Parameters of the objective function
-ALPHA = 2
+ALPHA = 1
 BETA = 1
 
 # Optional sweep of alpha to visualise its impact on the optimisation.

--- a/init.py
+++ b/init.py
@@ -23,8 +23,8 @@ OPERATIONAL_NODES = [0, 1, 2, 3, 4, 5]  # [] => OPF ; sinon => DOE
 PARENT_NODES = [0]
 CHILDREN_NODES = [1, 2, 3, 4, 5]
 # Parameters of the objective function
-ALPHA = 1
-BETA = 1
+ALPHA = 3
+BETA = 3
 
 # Optional sweep of alpha to visualise its impact on the optimisation.
 # Set ``PLOT_ALPHA`` to ``True`` to launch :func:`plot_alloc_alpha` with the
@@ -42,7 +42,6 @@ BETA_MIN = 1.0
 BETA_MAX = 4.0
 BETA_STEP = 0.1
 # ---------------------------------
-
 
 CHECK_REQ = False
 if CHECK_REQ:

--- a/viz/plot_DOE.py
+++ b/viz/plot_DOE.py
@@ -15,10 +15,6 @@ def plot_DOE(m, filename="Figures/Child_nodes_envelopes.pdf"):
     info = [getattr(m.info_DSO_param[n], "value", m.info_DSO_param[n]) for n in children]
     x = np.arange(len(children)) * 5e-4
 
-    # Debugging: print P_C_set values for each child node
-    for n, val0, val1 in zip(children, p0, p1):
-        print(f"Node {n}: P_C_set[0]={val0}, P_C_set[1]={val1}")
-
 
     plt.figure(figsize=(5, 6))
     for xs, hi, lo in zip(x, p0, p1):


### PR DESCRIPTION
## Summary
- calculate line current bounds directly in `build_graph_from_data`
- propagate per-unit current limits through `pyo_environment` parameters

## Testing
- `pytest`
- `python -m py_compile core/graph.py core/pyo_environment.py`


------
https://chatgpt.com/codex/tasks/task_e_68b045c7d0448323960e9c0211fe7813